### PR TITLE
Include subdirectories in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "files": [
-    "dist/*.d.ts",
-    "dist/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.js",
     "!dist/test*.*",
     "!dist/bundle.js"
   ],


### PR DESCRIPTION
Continuation of #5: I forgot to add ``/**/`` in ``files`` field in ``package.json``